### PR TITLE
ヘッダーのスペルミスを修正

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -22,7 +22,7 @@
                 = link_to 'Logout', destroy_user_session_path, method: :delete
           %li
             .btn.btn-default
-              = link_to "New Photo", new_prototype_path, style: "color: #337ab7;"
+              = link_to "New Proto", new_prototype_path, style: "color: #337ab7;"
       - else
         %ul.nav.navbar-nav.navbar-right
           %li


### PR DESCRIPTION
# What
ヘッダーの「New Photo」を「New Proto」に修正する。

# Why
スペルが間違っているため。